### PR TITLE
Add secrets header for Wi-Fi and MQTT configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .vscode/c_cpp_properties.json
 .vscode/launch.json
 .vscode/ipch
+
+include/Secrets.h

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# ESP8266 Roller Controller
+
+This project controls a roller blind using an ESP8266 module. Wi-Fi and MQTT
+credentials are stored in a separate configuration header to keep secrets out of
+version control.
+
+## Configuration
+
+Update `include/Secrets.h` with your network and MQTT settings:
+
+```cpp
+const char* WIFI_SSID = "your_wifi_ssid";
+const char* WIFI_PASSWORD = "your_wifi_password";
+const char* MQTT_HOST = "your.mqtt.host";
+```
+
+The file is listed in `.gitignore` so local changes won't be committed
+accidentally.
+
+## Building
+
+Use [PlatformIO](https://platformio.org/) to build the project:
+
+```bash
+pio run
+```

--- a/include/Secrets.h
+++ b/include/Secrets.h
@@ -1,0 +1,6 @@
+#pragma once
+
+const char* WIFI_SSID = "your_wifi_ssid";
+const char* WIFI_PASSWORD = "your_wifi_password";
+const char* MQTT_HOST = "your.mqtt.host";
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,11 +1,7 @@
 #include <ESP8266WiFi.h>
 #include <PubSubClient.h>
 #include <AccelStepper.h>
-
-// ===== CONFIG =====
-const char* ssid = ".RU-023";
-const char* password = "";
-const char* mqtt_server = "192.168.0.65";
+#include "Secrets.h"
 
 // MQTT topics
 #define TOPIC_POSITION   "/devices/roller_1/controls/position"
@@ -34,8 +30,8 @@ bool moving = false;
 
 void setup_wifi() {
   Serial.print("Connecting to WiFi: ");
-  Serial.println(ssid);
-  WiFi.begin(ssid, password);
+  Serial.println(WIFI_SSID);
+  WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
   while (WiFi.status() != WL_CONNECTED) {
     delay(500);
     Serial.print(".");
@@ -104,7 +100,7 @@ void setup() {
   Serial.begin(115200);
   Serial.println("=== Roller Blind Controller Starting ===");
   setup_wifi();
-  client.setServer(mqtt_server, 1883);
+  client.setServer(MQTT_HOST, 1883);
   client.setCallback(callback);
   stepper.setMaxSpeed(MOTOR_SPEED);
   stepper.setAcceleration(MOTOR_ACCEL);


### PR DESCRIPTION
## Summary
- Add `include/Secrets.h` for Wi-Fi and MQTT settings and ignore it in version control
- Use new constants in `src/main.cpp`
- Document configuration setup in README

## Testing
- `pio run`


------
https://chatgpt.com/codex/tasks/task_e_689cb29fe6ac83279cc41ed981445173