### PR TITLE
Add OTA update support and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: Build and OTA Deploy
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      ESP_HOST: ${{ secrets.ESP_HOST }}
+      ESP_PASS: ${{ secrets.ESP_PASS }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install PlatformIO
+        run: pip install -U platformio
+      - name: Build
+        run: pio run -e d1_mini
+      - name: OTA Upload
+        if: env.ESP_HOST != '' && env.ESP_PASS != ''
+        run: pio run -e d1_mini -t upload --upload-port $ESP_HOST --upload-password $ESP_PASS

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Update `include/Secrets.h` with your network and MQTT settings:
 const char* WIFI_SSID = "your_wifi_ssid";
 const char* WIFI_PASSWORD = "your_wifi_password";
 const char* MQTT_HOST = "your.mqtt.host";
+const char* OTA_PASSWORD = "your_ota_password";
 ```
 
 The file is listed in `.gitignore` so local changes won't be committed
@@ -24,3 +25,18 @@ Use [PlatformIO](https://platformio.org/) to build the project:
 ```bash
 pio run
 ```
+
+## Over-the-Air Updates
+
+The firmware supports OTA updates using `ArduinoOTA`. Set an OTA password in
+`include/Secrets.h` and upload over the network with PlatformIO:
+
+```bash
+pio run -t upload --upload-port <device-ip> --upload-password <your_ota_password>
+```
+
+## Continuous Integration
+
+GitHub Actions workflow `.github/workflows/ci.yml` builds the project on every
+push. When repository secrets `ESP_HOST` and `ESP_PASS` are configured, the
+workflow also uploads the firmware to the device via OTA.

--- a/include/Secrets.h
+++ b/include/Secrets.h
@@ -3,4 +3,5 @@
 const char* WIFI_SSID = "your_wifi_ssid";
 const char* WIFI_PASSWORD = "your_wifi_password";
 const char* MQTT_HOST = "your.mqtt.host";
+const char* OTA_PASSWORD = "your_ota_password";
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,6 +8,8 @@ board = d1_mini
 framework = arduino
 monitor_speed = 115200
 upload_speed = 921600
+upload_protocol = espota
+upload_port = 0.0.0.0
 lib_deps =
   PubSubClient
   AccelStepper
@@ -18,6 +20,8 @@ board = nodemcuv2
 framework = arduino
 monitor_speed = 115200
 upload_speed = 921600
+upload_protocol = espota
+upload_port = 0.0.0.0
 lib_deps =
   PubSubClient
   AccelStepper

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include <ESP8266WiFi.h>
 #include <PubSubClient.h>
 #include <AccelStepper.h>
+#include <ArduinoOTA.h>
 #include "Secrets.h"
 
 // MQTT topics
@@ -100,6 +101,11 @@ void setup() {
   Serial.begin(115200);
   Serial.println("=== Roller Blind Controller Starting ===");
   setup_wifi();
+
+  ArduinoOTA.setPassword(OTA_PASSWORD);
+  ArduinoOTA.begin();
+  Serial.println("OTA ready");
+
   client.setServer(MQTT_HOST, 1883);
   client.setCallback(callback);
   stepper.setMaxSpeed(MOTOR_SPEED);
@@ -108,6 +114,7 @@ void setup() {
 }
 
 void loop() {
+  ArduinoOTA.handle();
   if (!client.connected()) {
     reconnect();
   }


### PR DESCRIPTION
## Summary
- enable Arduino OTA in firmware
- configure PlatformIO for espota uploads
- add GitHub Actions workflow to build and optionally deploy via OTA

## Testing
- `pio run -e d1_mini`

------
https://chatgpt.com/codex/tasks/task_e_689cb6785e5c83279e9f096162d2a8b0