### PR TITLE
Add MQTT topics for recalibration and calibration reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ mosquitto_pub -h <mqtt_host> -t /devices/roller_1/controls/stop/on -m 1
 
 # Move to a specific position (0-100)
 mosquitto_pub -h <mqtt_host> -t /devices/roller_1/controls/position/on -m 50
+
+# Recalibrate current position as fully closed
+mosquitto_pub -h <mqtt_host> -t /devices/roller_1/controls/recalibrate/on -m 1
+
+# Reset stored calibration data
+mosquitto_pub -h <mqtt_host> -t /devices/roller_1/controls/reset_calibration/on -m 1
 ```
 
 ## Over-the-Air Updates

--- a/include/Config.h
+++ b/include/Config.h
@@ -7,17 +7,23 @@ constexpr char TOPIC_POSITION[] = "/devices/roller_1/controls/position";
 constexpr char TOPIC_OPEN[]     = "/devices/roller_1/controls/open";
 constexpr char TOPIC_CLOSE[]    = "/devices/roller_1/controls/close";
 constexpr char TOPIC_STOP[]     = "/devices/roller_1/controls/stop";
+constexpr char TOPIC_RECALIBRATE[]      = "/devices/roller_1/controls/recalibrate";
+constexpr char TOPIC_RESET_CALIBRATION[] = "/devices/roller_1/controls/reset_calibration";
 
 constexpr char TOPIC_POSITION_SET[] = "/devices/roller_1/controls/position/on";
 constexpr char TOPIC_OPEN_SET[]     = "/devices/roller_1/controls/open/on";
 constexpr char TOPIC_CLOSE_SET[]    = "/devices/roller_1/controls/close/on";
 constexpr char TOPIC_STOP_SET[]     = "/devices/roller_1/controls/stop/on";
+constexpr char TOPIC_RECALIBRATE_SET[]      = "/devices/roller_1/controls/recalibrate/on";
+constexpr char TOPIC_RESET_CALIBRATION_SET[] = "/devices/roller_1/controls/reset_calibration/on";
 
 constexpr char META_DEVICE[]   = "/devices/roller_1/meta";
 constexpr char META_POSITION[] = "/devices/roller_1/controls/position/meta";
 constexpr char META_OPEN[]     = "/devices/roller_1/controls/open/meta";
 constexpr char META_CLOSE[]    = "/devices/roller_1/controls/close/meta";
 constexpr char META_STOP[]     = "/devices/roller_1/controls/stop/meta";
+constexpr char META_RECALIBRATE[]      = "/devices/roller_1/controls/recalibrate/meta";
+constexpr char META_RESET_CALIBRATION[] = "/devices/roller_1/controls/reset_calibration/meta";
 
 // Stepper configuration
 constexpr int  MOTOR_PIN_1 = D1;

--- a/src/MotorController.cpp
+++ b/src/MotorController.cpp
@@ -39,3 +39,24 @@ void MotorController::stop() {
     currentState = RollerState::Idle;
 }
 
+void MotorController::recalibrate() {
+    stepper.setCurrentPosition(0);
+    currentPosPercent = 0;
+    EEPROM.put(0, currentPosPercent);
+    EEPROM.commit();
+    if (positionCb) {
+        positionCb(currentPosPercent);
+    }
+}
+
+void MotorController::resetCalibration() {
+    int invalid = -1;
+    EEPROM.put(0, invalid);
+    EEPROM.commit();
+    stepper.setCurrentPosition(0);
+    currentPosPercent = 0;
+    if (positionCb) {
+        positionCb(currentPosPercent);
+    }
+}
+

--- a/src/MotorController.h
+++ b/src/MotorController.h
@@ -13,6 +13,8 @@ public:
     void update();
     void moveToPercent(int percent);
     void stop();
+    void recalibrate();
+    void resetCalibration();
     int  currentPositionPercent() const { return currentPosPercent; }
     RollerState state() const { return currentState; }
     void setPositionCallback(PositionCallback cb) { positionCb = std::move(cb); }

--- a/src/NetworkManager.cpp
+++ b/src/NetworkManager.cpp
@@ -37,6 +37,8 @@ void NetworkManager::handleReconnect() {
         mqttClient.subscribe(Config::TOPIC_CLOSE_SET);
         mqttClient.subscribe(Config::TOPIC_STOP_SET);
         mqttClient.subscribe(Config::TOPIC_POSITION_SET);
+        mqttClient.subscribe(Config::TOPIC_RECALIBRATE_SET);
+        mqttClient.subscribe(Config::TOPIC_RESET_CALIBRATION_SET);
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,10 +14,14 @@ void publishMeta() {
     network.publish(Config::META_OPEN, "{\"type\":\"pushbutton\"}", true);
     network.publish(Config::META_CLOSE, "{\"type\":\"pushbutton\"}", true);
     network.publish(Config::META_STOP, "{\"type\":\"pushbutton\"}", true);
+    network.publish(Config::META_RECALIBRATE, "{\"type\":\"pushbutton\"}", true);
+    network.publish(Config::META_RESET_CALIBRATION, "{\"type\":\"pushbutton\"}", true);
     network.publish(Config::TOPIC_POSITION, String(motor.currentPositionPercent()), true);
     network.publish(Config::TOPIC_OPEN, "0", true);
     network.publish(Config::TOPIC_CLOSE, "0", true);
     network.publish(Config::TOPIC_STOP, "0", true);
+    network.publish(Config::TOPIC_RECALIBRATE, "0", true);
+    network.publish(Config::TOPIC_RESET_CALIBRATION, "0", true);
 }
 
 void handleMessage(const char* topic, const String& msg) {
@@ -34,6 +38,10 @@ void handleMessage(const char* topic, const String& msg) {
         } else {
             Serial.println("Invalid position value");
         }
+    } else if (strcmp(topic, Config::TOPIC_RECALIBRATE_SET) == 0) {
+        motor.recalibrate();
+    } else if (strcmp(topic, Config::TOPIC_RESET_CALIBRATION_SET) == 0) {
+        motor.resetCalibration();
     }
 }
 


### PR DESCRIPTION
## Summary
- add MQTT controls to trigger recalibration and to reset stored calibration
- implement recalibration and calibration reset routines in motor controller
- document new MQTT commands and expose metadata for UI

## Testing
- `pio run`

------
https://chatgpt.com/codex/tasks/task_e_689ce2a9d6148327be394395b8d25389