### PR TITLE
Add verbose debug output and open position calibration

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ mosquitto_pub -h <mqtt_host> -t /devices/roller_1/controls/position/on -m 50
 # Recalibrate current position as fully closed
 mosquitto_pub -h <mqtt_host> -t /devices/roller_1/controls/recalibrate/on -m 1
 
+# Calibrate current position as fully open
+mosquitto_pub -h <mqtt_host> -t /devices/roller_1/controls/calibrate_open/on -m 1
+
 # Reset stored calibration data
 mosquitto_pub -h <mqtt_host> -t /devices/roller_1/controls/reset_calibration/on -m 1
 ```

--- a/include/Config.h
+++ b/include/Config.h
@@ -9,6 +9,7 @@ constexpr char TOPIC_CLOSE[]    = "/devices/roller_1/controls/close";
 constexpr char TOPIC_STOP[]     = "/devices/roller_1/controls/stop";
 constexpr char TOPIC_RECALIBRATE[]      = "/devices/roller_1/controls/recalibrate";
 constexpr char TOPIC_RESET_CALIBRATION[] = "/devices/roller_1/controls/reset_calibration";
+constexpr char TOPIC_CALIBRATE_OPEN[]  = "/devices/roller_1/controls/calibrate_open";
 
 constexpr char TOPIC_POSITION_SET[] = "/devices/roller_1/controls/position/on";
 constexpr char TOPIC_OPEN_SET[]     = "/devices/roller_1/controls/open/on";
@@ -16,6 +17,7 @@ constexpr char TOPIC_CLOSE_SET[]    = "/devices/roller_1/controls/close/on";
 constexpr char TOPIC_STOP_SET[]     = "/devices/roller_1/controls/stop/on";
 constexpr char TOPIC_RECALIBRATE_SET[]      = "/devices/roller_1/controls/recalibrate/on";
 constexpr char TOPIC_RESET_CALIBRATION_SET[] = "/devices/roller_1/controls/reset_calibration/on";
+constexpr char TOPIC_CALIBRATE_OPEN_SET[]  = "/devices/roller_1/controls/calibrate_open/on";
 
 constexpr char META_DEVICE[]   = "/devices/roller_1/meta";
 constexpr char META_POSITION[] = "/devices/roller_1/controls/position/meta";
@@ -24,6 +26,7 @@ constexpr char META_CLOSE[]    = "/devices/roller_1/controls/close/meta";
 constexpr char META_STOP[]     = "/devices/roller_1/controls/stop/meta";
 constexpr char META_RECALIBRATE[]      = "/devices/roller_1/controls/recalibrate/meta";
 constexpr char META_RESET_CALIBRATION[] = "/devices/roller_1/controls/reset_calibration/meta";
+constexpr char META_CALIBRATE_OPEN[]  = "/devices/roller_1/controls/calibrate_open/meta";
 
 // Stepper configuration
 constexpr int  MOTOR_PIN_1 = D1;
@@ -35,7 +38,8 @@ constexpr int  MOTOR_SPEED = 500;
 constexpr int  MOTOR_ACCEL = 300;
 constexpr int  STEP_DELAY_US = 1200;
 
-constexpr int EEPROM_SIZE = 4;
+constexpr int EEPROM_SIZE = 8;
+constexpr long DEFAULT_MAX_STEPS = 4096;
 
 // Limit switch configuration
 constexpr bool USE_LIMIT_SWITCHES = false;

--- a/src/MotorController.cpp
+++ b/src/MotorController.cpp
@@ -6,21 +6,29 @@ void MotorController::begin() {
     stepper.setAcceleration(Config::MOTOR_ACCEL);
     EEPROM.begin(Config::EEPROM_SIZE);
     EEPROM.get(0, currentPosPercent);
+    EEPROM.get(sizeof(currentPosPercent), maxSteps);
     if (currentPosPercent < 0 || currentPosPercent > 100) {
         currentPosPercent = 0;
     }
-    long savedSteps = map(currentPosPercent, 0, 100, 0, 4096);
+    if (maxSteps <= 0) {
+        maxSteps = Config::DEFAULT_MAX_STEPS;
+    }
+    long savedSteps = map(currentPosPercent, 0, 100, 0, maxSteps);
     stepper.setCurrentPosition(savedSteps);
+    Serial.printf("Loaded position: %d%% (%ld/%ld steps)\n", currentPosPercent, savedSteps, maxSteps);
 }
 
 void MotorController::update() {
     if (currentState == RollerState::Moving) {
         stepper.run();
+        long cur = stepper.currentPosition();
+        Serial.printf("Step %ld/%ld (%d%%)\n", cur, stepper.targetPosition(), (int)map(cur, 0, maxSteps, 0, 100));
         if (stepper.distanceToGo() == 0) {
             currentState = RollerState::Idle;
-            currentPosPercent = map(stepper.currentPosition(), 0, 4096, 0, 100);
+            currentPosPercent = map(cur, 0, maxSteps, 0, 100);
             EEPROM.put(0, currentPosPercent);
             EEPROM.commit();
+            Serial.printf("Movement complete: %d%% (%ld steps)\n", currentPosPercent, cur);
             if (positionCb) {
                 positionCb(currentPosPercent);
             }
@@ -29,7 +37,8 @@ void MotorController::update() {
 }
 
 void MotorController::moveToPercent(int percent) {
-    long targetSteps = map(percent, 0, 100, 0, 4096);
+    long targetSteps = map(percent, 0, 100, 0, maxSteps);
+    Serial.printf("Move request: %d%% -> %ld steps (current %ld)\n", percent, targetSteps, stepper.currentPosition());
     stepper.moveTo(targetSteps);
     currentState = RollerState::Moving;
 }
@@ -37,13 +46,31 @@ void MotorController::moveToPercent(int percent) {
 void MotorController::stop() {
     stepper.stop();
     currentState = RollerState::Idle;
+    Serial.printf("Movement stopped at %ld steps (%d%%)\n", stepper.currentPosition(), (int)map(stepper.currentPosition(), 0, maxSteps, 0, 100));
 }
 
 void MotorController::recalibrate() {
     stepper.setCurrentPosition(0);
     currentPosPercent = 0;
     EEPROM.put(0, currentPosPercent);
+    EEPROM.put(sizeof(currentPosPercent), maxSteps);
     EEPROM.commit();
+    Serial.println("Calibrated closed position");
+    if (positionCb) {
+        positionCb(currentPosPercent);
+    }
+}
+
+void MotorController::calibrateOpen() {
+    maxSteps = stepper.currentPosition();
+    if (maxSteps < 0) {
+        maxSteps = 0;
+    }
+    currentPosPercent = 100;
+    EEPROM.put(0, currentPosPercent);
+    EEPROM.put(sizeof(currentPosPercent), maxSteps);
+    EEPROM.commit();
+    Serial.printf("Calibrated open position: %ld steps\n", maxSteps);
     if (positionCb) {
         positionCb(currentPosPercent);
     }
@@ -51,10 +78,14 @@ void MotorController::recalibrate() {
 
 void MotorController::resetCalibration() {
     int invalid = -1;
+    long invalidLong = -1;
     EEPROM.put(0, invalid);
+    EEPROM.put(sizeof(currentPosPercent), invalidLong);
     EEPROM.commit();
     stepper.setCurrentPosition(0);
     currentPosPercent = 0;
+    maxSteps = Config::DEFAULT_MAX_STEPS;
+    Serial.println("Calibration data reset");
     if (positionCb) {
         positionCb(currentPosPercent);
     }

--- a/src/MotorController.h
+++ b/src/MotorController.h
@@ -14,6 +14,7 @@ public:
     void moveToPercent(int percent);
     void stop();
     void recalibrate();
+    void calibrateOpen();
     void resetCalibration();
     int  currentPositionPercent() const { return currentPosPercent; }
     RollerState state() const { return currentState; }
@@ -23,5 +24,6 @@ private:
     AccelStepper stepper{Config::MOTOR_INTERFACE, Config::MOTOR_PIN_1, Config::MOTOR_PIN_3, Config::MOTOR_PIN_2, Config::MOTOR_PIN_4};
     RollerState currentState{RollerState::Idle};
     int currentPosPercent{0};
+    long maxSteps{Config::DEFAULT_MAX_STEPS};
     PositionCallback positionCb;
 };

--- a/src/NetworkManager.cpp
+++ b/src/NetworkManager.cpp
@@ -6,6 +6,7 @@ void NetworkManager::begin(MessageCallback cb) {
     callback = std::move(cb);
     WiFi.mode(WIFI_STA);
     WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+    Serial.printf("Connecting to WiFi: %s\n", WIFI_SSID);
     mqttClient.setServer(MQTT_HOST, 1883);
     mqttClient.setCallback([this](char* topic, byte* payload, unsigned int length) {
         if (length >= 100) {
@@ -21,6 +22,7 @@ void NetworkManager::begin(MessageCallback cb) {
 
 bool NetworkManager::update() {
     if (WiFi.status() != WL_CONNECTED) {
+        Serial.println("WiFi not connected");
         return false;
     }
     if (!mqttClient.connected()) {
@@ -32,13 +34,18 @@ bool NetworkManager::update() {
 }
 
 void NetworkManager::handleReconnect() {
+    Serial.printf("Connecting to MQTT at %s...\n", MQTT_HOST);
     if (mqttClient.connect("ESP8266_Roller")) {
+        Serial.println("MQTT connected");
         mqttClient.subscribe(Config::TOPIC_OPEN_SET);
         mqttClient.subscribe(Config::TOPIC_CLOSE_SET);
         mqttClient.subscribe(Config::TOPIC_STOP_SET);
         mqttClient.subscribe(Config::TOPIC_POSITION_SET);
         mqttClient.subscribe(Config::TOPIC_RECALIBRATE_SET);
         mqttClient.subscribe(Config::TOPIC_RESET_CALIBRATION_SET);
+        mqttClient.subscribe(Config::TOPIC_CALIBRATE_OPEN_SET);
+    } else {
+        Serial.println("MQTT connection failed");
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,15 +16,18 @@ void publishMeta() {
     network.publish(Config::META_STOP, "{\"type\":\"pushbutton\"}", true);
     network.publish(Config::META_RECALIBRATE, "{\"type\":\"pushbutton\"}", true);
     network.publish(Config::META_RESET_CALIBRATION, "{\"type\":\"pushbutton\"}", true);
+    network.publish(Config::META_CALIBRATE_OPEN, "{\"type\":\"pushbutton\"}", true);
     network.publish(Config::TOPIC_POSITION, String(motor.currentPositionPercent()), true);
     network.publish(Config::TOPIC_OPEN, "0", true);
     network.publish(Config::TOPIC_CLOSE, "0", true);
     network.publish(Config::TOPIC_STOP, "0", true);
     network.publish(Config::TOPIC_RECALIBRATE, "0", true);
     network.publish(Config::TOPIC_RESET_CALIBRATION, "0", true);
+    network.publish(Config::TOPIC_CALIBRATE_OPEN, "0", true);
 }
 
 void handleMessage(const char* topic, const String& msg) {
+    Serial.printf("MQTT message: %s => %s\n", topic, msg.c_str());
     if (strcmp(topic, Config::TOPIC_OPEN_SET) == 0) {
         motor.moveToPercent(100);
     } else if (strcmp(topic, Config::TOPIC_CLOSE_SET) == 0) {
@@ -42,6 +45,8 @@ void handleMessage(const char* topic, const String& msg) {
         motor.recalibrate();
     } else if (strcmp(topic, Config::TOPIC_RESET_CALIBRATION_SET) == 0) {
         motor.resetCalibration();
+    } else if (strcmp(topic, Config::TOPIC_CALIBRATE_OPEN_SET) == 0) {
+        motor.calibrateOpen();
     }
 }
 


### PR DESCRIPTION
## Summary
- add MQTT topics and handlers for calibrating fully open position
- track max steps in EEPROM and provide verbose step/position logging
- extend README with calibration instructions

## Testing
- `pio run`

------
https://chatgpt.com/codex/tasks/task_e_689da9d38c2c83279128d6b6b798c0c4