### PR TITLE
Throttle WiFi reconnect attempts

### DIFF
--- a/src/NetworkManager.cpp
+++ b/src/NetworkManager.cpp
@@ -22,7 +22,13 @@ void NetworkManager::begin(MessageCallback cb) {
 
 bool NetworkManager::update() {
     if (WiFi.status() != WL_CONNECTED) {
-        Serial.println("WiFi not connected");
+        unsigned long now = millis();
+        if (now - lastWifiReconnectAttempt >= 5000) {
+            Serial.println("WiFi not connected");
+            // Throttle reconnect attempts to once every 5 seconds
+            WiFi.reconnect();
+            lastWifiReconnectAttempt = now;
+        }
         return false;
     }
     if (!mqttClient.connected()) {

--- a/src/NetworkManager.h
+++ b/src/NetworkManager.h
@@ -19,4 +19,5 @@ private:
     WiFiClient wifiClient;
     PubSubClient mqttClient{wifiClient};
     MessageCallback callback;
+    unsigned long lastWifiReconnectAttempt = 0;
 };


### PR DESCRIPTION
## Summary
- throttle WiFi reconnect/logging to once every 5s to avoid flooding

## Testing
- `platformio run`

------
https://chatgpt.com/codex/tasks/task_e_689db1d4b6248327ad5177785809fa7b