### PR TITLE
Load secrets from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
 # ESP8266 Roller Controller
 
 This project controls a roller blind using an ESP8266 module. Wi-Fi and MQTT
-credentials are stored in a separate configuration header to keep secrets out of
+credentials are supplied at build time so they don't need to be stored in
 version control.
 
 ## Configuration
 
-Update `include/Secrets.h` with your network and MQTT settings:
+Before building, export the required credentials as environment variables:
 
-```cpp
-const char* WIFI_SSID = "your_wifi_ssid";
-const char* WIFI_PASSWORD = "your_wifi_password";
-const char* MQTT_HOST = "your.mqtt.host";
-const char* OTA_PASSWORD = "your_ota_password";
+```bash
+export WIFI_SSID="your_wifi_ssid"
+export WIFI_PASSWORD="your_wifi_password"
+export MQTT_HOST="your.mqtt.host"
+export OTA_PASSWORD="your_ota_password"
 ```
 
-The file is listed in `.gitignore` so local changes won't be committed
-accidentally.
+PlatformIO reads these variables and injects them into the firmware at compile
+time. The secrets themselves remain outside the repository.
 
 ## Building
 
@@ -57,8 +57,8 @@ mosquitto_pub -h <mqtt_host> -t /devices/roller_1/controls/reset_calibration/on 
 
 ## Over-the-Air Updates
 
-The firmware supports OTA updates using `ArduinoOTA`. Set an OTA password in
-`include/Secrets.h` and upload over the network with PlatformIO:
+The firmware supports OTA updates using `ArduinoOTA`. Ensure the `OTA_PASSWORD`
+environment variable is set and upload over the network with PlatformIO:
 
 ```bash
 pio run -t upload --upload-port <device-ip> --upload-password <your_ota_password>

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,6 +11,11 @@ upload_speed = 921600
 lib_deps =
   PubSubClient
   AccelStepper
+build_flags =
+  -DWIFI_SSID_VAL=\"${sysenv.WIFI_SSID}\"
+  -DWIFI_PASSWORD_VAL=\"${sysenv.WIFI_PASSWORD}\"
+  -DMQTT_HOST_VAL=\"${sysenv.MQTT_HOST}\"
+  -DOTA_PASSWORD_VAL=\"${sysenv.OTA_PASSWORD}\"
 
 ; Uncomment and configure the lines below to upload over-the-air.
 ; The device must already have OTA firmware and be reachable on the network.
@@ -28,6 +33,11 @@ upload_speed = 921600
 lib_deps =
   PubSubClient
   AccelStepper
+build_flags =
+  -DWIFI_SSID_VAL=\"${sysenv.WIFI_SSID}\"
+  -DWIFI_PASSWORD_VAL=\"${sysenv.WIFI_PASSWORD}\"
+  -DMQTT_HOST_VAL=\"${sysenv.MQTT_HOST}\"
+  -DOTA_PASSWORD_VAL=\"${sysenv.OTA_PASSWORD}\"
 
 ; OTA upload configuration (optional)
 ;upload_protocol = espota

--- a/src/Secrets.cpp
+++ b/src/Secrets.cpp
@@ -1,6 +1,19 @@
 #include "Secrets.h"
 
-const char* WIFI_SSID = "your_wifi_ssid";
-const char* WIFI_PASSWORD = "your_wifi_password";
-const char* MQTT_HOST = "your.mqtt.host";
-const char* OTA_PASSWORD = "your_ota_password";
+#ifndef WIFI_SSID_VAL
+#error "WIFI_SSID environment variable not defined"
+#endif
+#ifndef WIFI_PASSWORD_VAL
+#error "WIFI_PASSWORD environment variable not defined"
+#endif
+#ifndef MQTT_HOST_VAL
+#error "MQTT_HOST environment variable not defined"
+#endif
+#ifndef OTA_PASSWORD_VAL
+#error "OTA_PASSWORD environment variable not defined"
+#endif
+
+const char* WIFI_SSID = WIFI_SSID_VAL;
+const char* WIFI_PASSWORD = WIFI_PASSWORD_VAL;
+const char* MQTT_HOST = MQTT_HOST_VAL;
+const char* OTA_PASSWORD = OTA_PASSWORD_VAL;


### PR DESCRIPTION
## Summary
- Replace hardcoded secrets with compile-time environment variables
- Inject Wi-Fi, MQTT and OTA credentials through PlatformIO build flags
- Document new environment variable approach in README

## Testing
- `pio run`
- `pio test` *(fails: Nothing to build. Please put your test suites to the '/workspace/ESP8266-RollerController/test' folder)*


------
https://chatgpt.com/codex/tasks/task_e_689db7bf296883278a09d1badcc33c10